### PR TITLE
Adapt the code to work with cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 #     Run the build commands from within the Developer Command Prompt window to have paths to the compiler and runtime libraries set.
 #     You must have git.exe in your %PATH% environment variable.
 #
-# To build Vidardb for Windows is as easy as 1-2-3-4-5:
+# To build VidarDB for Windows is as easy as 1-2-3-4-5:
 #
 # 1. Update paths to third-party libraries in thirdparty.inc file
 # 2. Create a new directory for build artifacts
@@ -195,7 +195,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-memcmp")
 endif()
 
-option(VIDARDB_LITE "Build VidardbLite version" OFF)
+option(VIDARDB_LITE "Build VidarDBLite version" OFF)
 if(VIDARDB_LITE)
   add_definitions(-DVIDARDB_LITE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
-# This cmake build is for Windows 64-bit only.
+# Prerequisites for Windows:
+#     This cmake build is for Windows 64-bit only.
 #
 # Prerequisites:
-#     You must have Visual Studio 2013 Update 4 installed. Start the Developer Command Prompt window that is a part of Visual Studio installation.
+#     You must have at least Visual Studio 2015 Update 3. Start the Developer Command Prompt window that is a part of Visual Studio installation.
 #     Run the build commands from within the Developer Command Prompt window to have paths to the compiler and runtime libraries set.
 #     You must have git.exe in your %PATH% environment variable.
 #
-# To build VidarDB for Windows is as easy as 1-2-3-4-5:
+# To build Vidardb for Windows is as easy as 1-2-3-4-5:
 #
 # 1. Update paths to third-party libraries in thirdparty.inc file
 # 2. Create a new directory for build artifacts
@@ -13,8 +14,7 @@
 #        cd build
 # 3. Run cmake to generate project files for Windows, add more options to enable required third-party libraries.
 #    See thirdparty.inc for more information.
-#        sample command: cmake -G "Visual Studio 12 Win64" -DGFLAGS=1 -DSNAPPY=1 -DJEMALLOC=1 -DJNI=1 ..
-#        OR for VS Studio 15 cmake -G "Visual Studio 14 Win64" -DGFLAGS=1 -DSNAPPY=1 -DJEMALLOC=1 -DJNI=1 ..
+#        sample command: cmake -G "Visual Studio 14 Win64" -DGFLAGS=1 -DSNAPPY=1 -DJEMALLOC=1 -DJNI=1 ..
 # 4. Then build the project in debug mode (you may want to add /m[:<N>] flag to run msbuild in <N> parallel threads
 #                                          or simply /m ot use all avail cores)
 #        msbuild vidardb.sln
@@ -25,41 +25,149 @@
 # 5. And release mode (/m[:<N>] is also supported)
 #        msbuild vidardb.sln /p:Configuration=Release
 #
+# Linux:
+#
+# 1. Install a recent toolchain such as devtoolset-3 if you're on a older distro. C++11 required.
+# 2. mkdir build; cd build
+# 3. cmake ..
+# 4. make -j
 
 cmake_minimum_required(VERSION 2.6)
 project(vidardb)
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty.inc)
-execute_process(COMMAND powershell -Command "Get-Date -format MM_dd_yyyy" OUTPUT_VARIABLE DATE)
-execute_process(COMMAND powershell -Command "Get-Date -format HH:mm:ss" OUTPUT_VARIABLE TIME)
-string(REGEX REPLACE "(..)_(..)_..(..).*" "\\1/\\2/\\3" DATE ${DATE})
-string(REGEX REPLACE "(..):(.....).*" " \\1:\\2" TIME ${TIME})
-string(CONCAT GIT_DATE_TIME ${DATE} ${TIME})
+if(POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW)
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
+
+if(WIN32)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty.inc)
+else()
+  option(WITH_JEMALLOC "build with JeMalloc" OFF)
+  if(WITH_JEMALLOC)
+    find_package(JeMalloc REQUIRED)
+    add_definitions(-DVIDARDB_JEMALLOC)
+    include_directories(${JEMALLOC_INCLUDE_DIR})
+  endif()
+  if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    # FreeBSD has jemaloc as default malloc
+    add_definitions(-DVIDARDB_JEMALLOC)
+    set(WITH_JEMALLOC ON)
+  endif()
+  option(WITH_SNAPPY "build with SNAPPY" OFF)
+  if(WITH_SNAPPY)
+    find_package(snappy REQUIRED)
+    add_definitions(-DSNAPPY)
+    include_directories(${SNAPPY_INCLUDE_DIR})
+    list(APPEND THIRDPARTY_LIBS ${SNAPPY_LIBRARIES})
+  endif()
+endif()
+
+if(WIN32)
+  execute_process(COMMAND powershell -Command "Get-Date -format MM_dd_yyyy" OUTPUT_VARIABLE DATE)
+  execute_process(COMMAND powershell -Command "Get-Date -format HH:mm:ss" OUTPUT_VARIABLE TIME)
+  string(REGEX REPLACE "(..)_(..)_..(..).*" "\\1/\\2/\\3" DATE "${DATE}")
+  string(REGEX REPLACE "(..):(.....).*" " \\1:\\2" TIME "${TIME}")
+  set(GIT_DATE_TIME "${DATE} ${TIME}")
+else()
+  execute_process(COMMAND date "+%Y/%m/%d %H:%M:%S" OUTPUT_VARIABLE DATETIME)
+  string(REGEX REPLACE "\n" "" DATETIME ${DATETIME})
+  set(GIT_DATE_TIME "${DATETIME}")
+endif()
 
 find_package(Git)
 
 if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+  if(WIN32)
     execute_process(COMMAND $ENV{COMSPEC} /C ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} rev-parse HEAD OUTPUT_VARIABLE GIT_SHA)
+  else()
+    execute_process(COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} rev-parse HEAD OUTPUT_VARIABLE GIT_SHA)
+  endif()
 else()
-    set(GIT_SHA 0)
+  set(GIT_SHA 0)
 endif()
 
-string(REGEX REPLACE "[^0-9a-f]+" "" GIT_SHA ${GIT_SHA})
+string(REGEX REPLACE "[^0-9a-f]+" "" GIT_SHA "${GIT_SHA}")
 
-set(BUILD_VERSION_CC ${CMAKE_CURRENT_SOURCE_DIR}/util/build_version.cc)
+if (NOT WIN32)
+  execute_process(COMMAND
+      "./build_tools/version.sh" "full"
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      OUTPUT_VARIABLE VIDARDB_VERSION
+  )
+  string(STRIP "${VIDARDB_VERSION}" VIDARDB_VERSION)
+  execute_process(COMMAND
+      "./build_tools/version.sh" "major"
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      OUTPUT_VARIABLE VIDARDB_VERSION_MAJOR
+  )
+  string(STRIP "${VIDARDB_VERSION_MAJOR}" VIDARDB_VERSION_MAJOR)
+endif()
 
-add_custom_command(OUTPUT ${BUILD_VERSION_CC}
-    COMMAND echo "#include \"build_version.h\"" > ${BUILD_VERSION_CC}
-    COMMAND echo "const char* vidardb_build_git_sha = \"vidardb_build_git_sha:${GIT_SHA}\";" >> ${BUILD_VERSION_CC}
-    COMMAND echo "const char* vidardb_build_git_datetime = \"vidardb_build_git_datetime:${GIT_DATE_TIME}\";" >> ${BUILD_VERSION_CC}
-    COMMAND echo const char* vidardb_build_compile_date = __DATE__\; >> ${BUILD_VERSION_CC}
-)
+set(BUILD_VERSION_CC ${CMAKE_BINARY_DIR}/build_version.cc)
+configure_file(util/build_version.cc.in ${BUILD_VERSION_CC} @ONLY)
+add_library(build_version OBJECT ${BUILD_VERSION_CC})
+target_include_directories(build_version PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/util)
+if(WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /nologo  /EHsc /GS /Gd /GR /GF /fp:precise /Zc:wchar_t /Zc:forScope /errorReport:queue")
 
-add_custom_target(GenerateBuildVersion DEPENDS ${BUILD_VERSION_CC})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /wd4127 /wd4800 /wd4996 /wd4351")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W -Wextra -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-compare -Wshadow -Wno-unused-parameter -Wno-unused-variable -Woverloaded-virtual -Wnon-virtual-dtor -Wno-missing-field-initializers")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("-momit-leaf-frame-pointer" HAVE_OMIT_LEAF_FRAME_POINTER)
+    if(HAVE_OMIT_LEAF_FRAME_POINTER)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
+    endif()
+  endif()
+endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /nologo  /EHsc /GS /Gd /GR /GF /fp:precise /Zc:wchar_t /Zc:forScope /errorReport:queue")
+option(FAIL_ON_WARNINGS "Treat compile warnings as errors" ON)
+if(FAIL_ON_WARNINGS)
+  if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
+  else() # assume GCC
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  endif()
+endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FC /d2Zi+ /W3 /WX /wd4127 /wd4800 /wd4996 /wd4351")
+option(WITH_ASAN "build with ASAN" OFF)
+if(WITH_ASAN)
+  add_definitions(-DVIDARDB_TSAN_RUN)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+  if(WITH_JEMALLOC)
+    message(FATAL "ASAN does not work well with JeMalloc")
+  endif()
+endif()
+
+option(WITH_TSAN "build with TSAN" OFF)
+if(WITH_TSAN)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread -pie")
+  add_definitions(-DVIDARDB_TSAN_RUN)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -fPIC")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=thread -fPIC")
+  if(WITH_JEMALLOC)
+    message(FATAL "TSAN does not work well with JeMalloc")
+  endif()
+endif()
+
+option(WITH_UBSAN "build with UBSAN" OFF)
+if(WITH_UBSAN)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined")
+  if(WITH_JEMALLOC)
+    message(FATAL "UBSAN does not work well with JeMalloc")
+  endif()
+endif()
 
 # Used to run CI build and tests so we can run faster
 set(OPTIMIZE_DEBUG_DEFAULT 0)        # Debug build is unoptimized by default use -DOPTDBG=1 to optimize
@@ -70,39 +178,96 @@ else()
    set(OPTIMIZE_DEBUG ${OPTIMIZE_DEBUG_DEFAULT})
 endif()
 
-if((${OPTIMIZE_DEBUG} EQUAL 1))
-   message(STATUS "Debug optimization is enabled")
-   set(CMAKE_CXX_FLAGS_DEBUG "/Oxt /MDd")
-else()
-   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Od /RTC1 /Gm /MDd")
+if(WIN32)
+  if((${OPTIMIZE_DEBUG} EQUAL 1))
+    message(STATUS "Debug optimization is enabled")
+    set(CMAKE_CXX_FLAGS_DEBUG "/Oxt /MDd")
+  else()
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Od /RTC1 /Gm /MDd")
+  endif()
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Oxt /Zp8 /Gm- /Gy /MD")
+
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG")
 endif()
 
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Oxt /Zp8 /Gm- /Gy /MD")
+if(CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-builtin-memcmp")
+endif()
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG")
+option(VIDARDB_LITE "Build VidardbLite version" OFF)
+if(VIDARDB_LITE)
+  add_definitions(-DVIDARDB_LITE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+endif()
 
-add_definitions(-DWIN32 -DOS_WIN -D_MBCS -DWIN64 -DNOMINMAX)
+if(CMAKE_SYSTEM_NAME MATCHES "Cygwin")
+  add_definitions(-fno-builtin-memcmp -DCYGWIN)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  add_definitions(-DOS_MACOSX)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES arm)
+    add_definitions(-DIOS_CROSS_COMPILE -DVIDARDB_LITE)
+    # no debug info for IOS, that will make our library big
+    add_definitions(-DNDEBUG)
+  endif()
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  add_definitions(-DOS_LINUX)
+elseif(CMAKE_SYSTEM_NAME MATCHES "SunOS")
+  add_definitions(-DOS_SOLARIS)
+elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+  add_definitions(-DOS_FREEBSD)
+elseif(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+  add_definitions(-DOS_NETBSD)
+elseif(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+  add_definitions(-DOS_OPENBSD)
+elseif(CMAKE_SYSTEM_NAME MATCHES "DragonFly")
+  add_definitions(-DOS_DRAGONFLYBSD)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Android")
+  add_definitions(-DOS_ANDROID)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
+  add_definitions(-DWIN32 -DOS_WIN -D_MBCS -DWIN64 -DNOMINMAX)
+endif()
+
+if(NOT WIN32)
+  add_definitions(-DVIDARDB_PLATFORM_POSIX -DVIDARDB_LIB_IO_POSIX)
+endif()
+
+option(WITH_FALLOCATE "build with fallocate" ON)
+
+if(WITH_FALLOCATE)
+  include(CheckCSourceCompiles)
+  CHECK_C_SOURCE_COMPILES("
+#include <fcntl.h>
+#include <linux/falloc.h>
+int main() {
+ int fd = open(\"/dev/null\", 0);
+ fallocate(fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE, 0, 1024);
+}
+" HAVE_FALLOCATE)
+  if(HAVE_FALLOCATE)
+    add_definitions(-DVIDARDB_FALLOCATE_PRESENT)
+  endif()
+endif()
+
+include(CheckFunctionExists)
+CHECK_FUNCTION_EXISTS(malloc_usable_size HAVE_MALLOC_USABLE_SIZE)
+if(HAVE_MALLOC_USABLE_SIZE)
+  add_definitions(-DVIDARDB_MALLOC_USABLE_SIZE)
+endif()
 
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_SOURCE_DIR}/third-party/gtest-1.7.0/fused-src)
-
-set(VIDARDB_LIBS vidardblib${ARTIFACT_SUFFIX})
-set(THIRDPARTY_LIBS ${THIRDPARTY_LIBS} gtest)
-set(SYSTEM_LIBS ${SYSTEM_LIBS} Shlwapi.lib Rpcrt4.lib)
-
-set(LIBS ${VIDARDB_LIBS} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/third-party/gtest-1.7.0/fused-src)
+find_package(Threads REQUIRED)
 
 add_subdirectory(third-party/gtest-1.7.0/fused-src/gtest)
 
 # Main library source code
+
 set(SOURCES
         db/auto_roll_logger.cc
         db/builder.cc
-        db/c.cc
         db/column_family.cc
-        db/compacted_db_impl.cc
         db/compaction.cc
         db/compaction_iterator.cc
         db/compaction_job.cc
@@ -112,12 +277,10 @@ set(SOURCES
         db/db_filesnapshot.cc
         db/db_impl.cc
         db/db_impl_debug.cc
-        db/db_impl_experimental.cc
         db/db_impl_readonly.cc
         db/db_info_dumper.cc
         db/db_iter.cc
         db/event_helpers.cc
-        db/experimental.cc
         db/filename.cc
         db/file_indexer.cc
         db/flush_job.cc
@@ -126,14 +289,10 @@ set(SOURCES
         db/internal_stats.cc
         db/log_reader.cc
         db/log_writer.cc
-        db/managed_iterator.cc
         memtable/memtable.cc
         memtable/memtable_allocator.cc
         memtable/memtable_list.cc
-        db/merge_helper.cc
-        db/merge_operator.cc
         db/repair.cc
-        db/slice.cc
         db/snapshot_impl.cc
         db/table_cache.cc
         db/table_properties_collector.cc
@@ -146,53 +305,30 @@ set(SOURCES
         db/write_batch_base.cc
         db/write_controller.cc
         db/write_thread.cc
-        db/xfunc_test_points.cc
-        memtable/hash_cuckoo_rep.cc
-        memtable/hash_linklist_rep.cc
-        memtable/hash_skiplist_rep.cc
         memtable/skiplistrep.cc
-        memtable/vectorrep.cc
         port/stack_trace.cc
-        port/win/io_win.cc
-        port/win/env_win.cc
-        port/win/env_default.cc
-        port/win/port_win.cc
-        port/win/win_logger.cc
-        port/win/xpress_win.cc
         table/adaptive_table_factory.cc
         table/block.cc
-        table/block_based_filter_block.cc
         table/block_based_table_builder.cc
         table/block_based_table_factory.cc
         table/block_based_table_reader.cc
+        table/column_table_builder.cc
+        table/column_table_factory.cc
+        table/column_table_reader.cc
+        table/column_block_builder.cc
         table/block_builder.cc
-        table/block_prefix_index.cc
-        table/bloom_block.cc
-        table/cuckoo_table_builder.cc
-        table/cuckoo_table_factory.cc
-        table/cuckoo_table_reader.cc
         table/flush_block_policy.cc
         table/format.cc
-        table/full_filter_block.cc
         table/get_context.cc
         table/iterator.cc
-        table/merger.cc
         table/sst_file_writer.cc
+        table/merger.cc
         table/meta_blocks.cc
-        table/plain_table_builder.cc
-        table/plain_table_factory.cc
-        table/plain_table_index.cc
-        table/plain_table_key_coding.cc
-        table/plain_table_reader.cc
-        table/persistent_cache_helper.cc
         table/table_properties.cc
         table/two_level_iterator.cc
-        tools/sst_dump_tool.cc
-        tools/db_bench_tool.cc
-        tools/dump/db_dump_tool.cc
         util/arena.cc
-        util/bloom.cc
         util/build_version.cc
+        util/mutable_cf_options.cc
         util/cache.cc
         util/coding.cc
         util/compaction_job_stats_impl.cc
@@ -201,27 +337,19 @@ set(SOURCES
         util/concurrent_arena.cc
         util/crc32c.cc
         util/delete_scheduler.cc
-        util/dynamic_bloom.cc
         util/env.cc
-        util/env_chroot.cc
-        util/env_hdfs.cc
         util/event_logger.cc
         util/file_util.cc
         util/file_reader_writer.cc
         util/sst_file_manager_impl.cc
-        util/filter_policy.cc
         util/hash.cc
         util/histogram.cc
-        util/histogram_windowing.cc
         util/instrumented_mutex.cc
         util/iostats_context.cc
-        tools/ldb_cmd.cc
-        tools/ldb_tool.cc
+        
         util/logging.cc
         util/log_buffer.cc
-        util/memenv.cc
         util/murmurhash.cc
-        util/mutable_cf_options.cc
         util/options.cc
         util/options_helper.cc
         util/options_parser.cc
@@ -229,244 +357,97 @@ set(SOURCES
         util/perf_context.cc
         util/perf_level.cc
         util/random.cc
-        util/rate_limiter.cc
         util/slice.cc
         util/statistics.cc
         util/status.cc
         util/status_message.cc
         util/string_util.cc
         util/sync_point.cc
-        util/testharness.cc
-        util/testutil.cc
         util/thread_local.cc
-        util/threadpool.cc
         util/thread_status_impl.cc
         util/thread_status_updater.cc
         util/thread_status_util.cc
         util/thread_status_util_debug.cc
-        util/transaction_test_util.cc
-        util/xfunc.cc
-        util/xxhash.cc
-        utilities/backupable/backupable_db.cc
-        utilities/checkpoint/checkpoint.cc
-        utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc
-        utilities/document/document_db.cc
-        utilities/document/json_document.cc
-        utilities/document/json_document_builder.cc
-        utilities/env_mirror.cc
-        utilities/env_registry.cc
-        utilities/flashcache/flashcache.cc
-        utilities/geodb/geodb_impl.cc
-        utilities/leveldb_options/leveldb_options.cc
-        utilities/memory/memory_util.cc
-        utilities/merge_operators/string_append/stringappend.cc
-        utilities/merge_operators/string_append/stringappend2.cc
-        utilities/merge_operators/put.cc
-        utilities/merge_operators/max.cc
-        utilities/merge_operators/uint64add.cc
-        utilities/options/options_util.cc
-        utilities/persistent_cache/persistent_cache_tier.cc
-        utilities/persistent_cache/volatile_tier_impl.cc
-        utilities/redis/redis_lists.cc
-        utilities/spatialdb/spatial_db.cc
-        utilities/table_properties_collectors/compact_on_deletion_collector.cc
-        utilities/transactions/optimistic_transaction_impl.cc
-        utilities/transactions/optimistic_transaction_db_impl.cc
+
         utilities/transactions/transaction_base.cc
         utilities/transactions/transaction_impl.cc
         utilities/transactions/transaction_db_impl.cc
         utilities/transactions/transaction_db_mutex_impl.cc
         utilities/transactions/transaction_lock_mgr.cc
         utilities/transactions/transaction_util.cc
-        utilities/ttl/db_ttl_impl.cc
         utilities/write_batch_with_index/write_batch_with_index.cc
         utilities/write_batch_with_index/write_batch_with_index_internal.cc
-)
+        $<TARGET_OBJECTS:build_version>)
 
-# For test util library that is build only in DEBUG mode
-# and linked to tests. Add test only code that is not #ifdefed for Release here.
-set(TESTUTIL_SOURCE
-    db/db_test_util.cc
-    table/mock_table.cc
-    util/mock_env.cc
-    util/fault_injection_test_env.cc
-    util/thread_status_updater_debug.cc
-)
-
-add_library(vidardblib${ARTIFACT_SUFFIX} ${SOURCES})
-set_target_properties(vidardblib${ARTIFACT_SUFFIX} PROPERTIES COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/vidardblib${ARTIFACT_SUFFIX}.pdb")
-add_dependencies(vidardblib${ARTIFACT_SUFFIX} GenerateBuildVersion)
-
-add_library(vidardb${ARTIFACT_SUFFIX} SHARED ${SOURCES})
-set_target_properties(vidardb${ARTIFACT_SUFFIX} PROPERTIES COMPILE_FLAGS "-DVIDARDB_DLL -DVIDARDB_LIBRARY_EXPORTS /Fd${CMAKE_CFG_INTDIR}/vidardb${ARTIFACT_SUFFIX}.pdb")
-add_dependencies(vidardb${ARTIFACT_SUFFIX} GenerateBuildVersion)
-target_link_libraries(vidardb${ARTIFACT_SUFFIX} ${LIBS})
-
-if (DEFINED JNI)
-  if (${JNI} EQUAL 1)
-    message(STATUS "JNI library is enabled")
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/java)
-  else()
-    message(STATUS "JNI library is disabled")
-  endif()
+if(WIN32)
+  list(APPEND SOURCES
+    port/win/io_win.cc
+    port/win/env_win.cc
+    port/win/env_default.cc
+    port/win/port_win.cc
+    port/win/win_logger.cc
+    port/win/xpress_win.cc)
 else()
-  message(STATUS "JNI library is disabled")
+  list(APPEND SOURCES
+    port/port_posix.cc
+    util/env_posix.cc
+    util/io_posix.cc)
 endif()
 
-set(APPS
-        tools/db_bench.cc
-        memtable/memtablerep_bench.cc
-        table/table_reader_bench.cc
-        tools/db_stress.cc
-        tools/write_stress.cc
-        tools/db_repl_stress.cc
-        tools/ldb.cc
-        tools/sst_dump.cc
-        tools/dump/vidardb_dump.cc
-        tools/dump/vidardb_undump.cc
-        util/cache_bench.cc
-        utilities/persistent_cache/hash_table_bench.cc
-)
+if(WIN32)
+  set(SYSTEM_LIBS ${SYSTEM_LIBS} Shlwapi.lib Rpcrt4.lib)
+  set(VIDARDB_STATIC_LIB vidardblib${ARTIFACT_SUFFIX})
+  set(VIDARDB_IMPORT_LIB vidardb${ARTIFACT_SUFFIX})
+  set(LIBS ${VIDARDB_STATIC_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+else()
+  set(SYSTEM_LIBS ${CMAKE_THREAD_LIBS_INIT} rt)
+  set(VIDARDB_STATIC_LIB vidardb${ARTIFACT_SUFFIX})
+  set(VIDARDB_SHARED_LIB vidardb-shared)
+  set(VIDARDB_IMPORT_LIB ${VIDARDB_SHARED_LIB})
+  set(LIBS ${VIDARDB_SHARED_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 
-set(C_TESTS db/c_test.c)
+  add_library(${VIDARDB_SHARED_LIB} SHARED ${SOURCES})
+  target_link_libraries(${VIDARDB_SHARED_LIB}
+    ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+  set_target_properties(${VIDARDB_SHARED_LIB} PROPERTIES
+                        LINKER_LANGUAGE CXX
+                        VERSION ${VIDARDB_VERSION}
+                        SOVERSION ${VIDARDB_VERSION_MAJOR}
+                        CXX_STANDARD 11
+                        OUTPUT_NAME "vidardb")
+endif()
 
-set(TESTS
-        test/db/auto_roll_logger_test.cc
-        test/db/column_family_test.cc
-        test/db/compact_files_test.cc
-        test/db/compaction_iterator_test.cc
-        test/db/compaction_job_test.cc
-        test/db/compaction_job_stats_test.cc
-        test/db/compaction_picker_test.cc
-        test/db/comparator_db_test.cc
-        test/db/corruption_test.cc
-        test/db/cuckoo_table_db_test.cc
-        test/db/db_compaction_filter_test.cc
-        test/db/db_compaction_test.cc
-        test/db/db_dynamic_level_test.cc
-        test/db/db_inplace_update_test.cc
-        test/db/db_iter_test.cc
-        test/db/db_log_iter_test.cc
-        test/db/db_properties_test.cc
-        test/db/db_table_properties_test.cc
-        test/db/db_tailing_iter_test.cc
-        test/db/db_test.cc
-        test/db/db_test2.cc
-        test/db/db_block_cache_test.cc
-        test/db/db_bloom_filter_test.cc
-        test/db/db_iterator_test.cc
-        test/db/db_sst_test.cc
-        test/db/db_universal_compaction_test.cc
-        test/db/db_wal_test.cc
-        test/db/dbformat_test.cc
-        test/db/deletefile_test.cc
-        test/db/fault_injection_test.cc
-        test/db/file_indexer_test.cc
-        test/db/filename_test.cc
-        test/db/flush_job_test.cc
-        test/db/inlineskiplist_test.cc
-        test/db/listener_test.cc
-        test/db/log_test.cc
-        test/db/manual_compaction_test.cc
-        test/memtable/memtable_list_test.cc
-        test/db/merge_test.cc
-        test/db/merge_helper_test.cc
-        test/db/options_file_test.cc
-        test/db/perf_context_test.cc
-        test/db/plain_table_db_test.cc
-        test/db/prefix_test.cc
-        test/db/repair_test.cc
-        test/db/skiplist_test.cc
-        test/db/table_properties_collector_test.cc
-        test/db/version_builder_test.cc
-        test/db/version_edit_test.cc
-        test/db/version_set_test.cc
-        test/db/wal_manager_test.cc
-        test/db/write_batch_test.cc
-        test/db/write_callback_test.cc
-        test/db/write_controller_test.cc
-        test/db/db_io_failure_test.cc
-        test/table/block_based_filter_block_test.cc
-        test/table/block_test.cc
-        test/table/cuckoo_table_builder_test.cc
-        test/table/cuckoo_table_reader_test.cc
-        test/table/full_filter_block_test.cc
-        test/table/merger_test.cc
-        test/table/table_test.cc
-        test/tools/db_sanity_test.cc
-        test/tools/ldb_cmd_test.cc
-        test/tools/reduce_levels_test.cc
-        test/tools/sst_dump_test.cc
-        test/util/arena_test.cc
-        test/util/autovector_test.cc
-        test/util/bloom_test.cc
-        test/util/cache_test.cc
-        test/util/coding_test.cc
-        test/util/crc32c_test.cc
-        test/util/delete_scheduler_test.cc
-        test/util/dynamic_bloom_test.cc
-        test/util/env_basic_test.cc
-        test/util/env_test.cc
-        test/util/event_logger_test.cc
-        test/util/filelock_test.cc
-        test/util/file_reader_writer_test.cc
-        test/util/heap_test.cc
-        test/util/histogram_test.cc
-        test/util/iostats_context_test.cc
-        test/util/mock_env_test.cc
-        test/util/options_settable_test.cc
-        test/util/options_test.cc
-        test/util/rate_limiter_test.cc
-        test/util/slice_transform_test.cc
-        test/util/thread_list_test.cc
-        test/util/thread_local_test.cc
-)
+option(WITH_LIBRADOS "Build with librados" OFF)
+if(WITH_LIBRADOS)
+  list(APPEND SOURCES
+    utilities/env_librados.cc)
+  list(APPEND THIRDPARTY_LIBS rados)
+endif()
 
-set(EXES ${APPS})
+add_library(${VIDARDB_STATIC_LIB} STATIC ${SOURCES})
+target_link_libraries(${VIDARDB_STATIC_LIB}
+  ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 
-foreach(sourcefile ${EXES})
-    string(REPLACE ".cc" "" exename ${sourcefile})
-    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
-    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
-    target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${LIBS})
-endforeach(sourcefile ${EXES})
+if(WIN32)
+  set_target_properties(${VIDARDB_STATIC_LIB} PROPERTIES
+    COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/${VIDARDB_STATIC_LIB}.pdb")
+endif()
 
-# test utilities are only build in debug
-set(TESTUTILLIB testutillib${ARTIFACT_SUFFIX})
-add_library(${TESTUTILLIB} STATIC ${TESTUTIL_SOURCE})
-set_target_properties(${TESTUTILLIB} PROPERTIES COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/testutillib${ARTIFACT_SUFFIX}.pdb")
-set_target_properties(${TESTUTILLIB}
-      PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD_RELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
-      )
+if(WIN32)
+  add_library(${VIDARDB_IMPORT_LIB} SHARED ${SOURCES})
+  target_link_libraries(${VIDARDB_IMPORT_LIB}
+    ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+  set_target_properties(${VIDARDB_IMPORT_LIB} PROPERTIES
+    COMPILE_FLAGS "-DVIDARDB_DLL -DVIDARDB_LIBRARY_EXPORTS /Fd${CMAKE_CFG_INTDIR}/${VIDARDB_IMPORT_LIB}.pdb")
+else()
+endif()
 
-# Tests are excluded from Release builds
-set(TEST_EXES ${TESTS})
-
-foreach(sourcefile ${TEST_EXES})
-    string(REPLACE ".cc" "" exename ${sourcefile})
-    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
-    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
-    set_target_properties(${exename}${ARTIFACT_SUFFIX}
-      PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD_RELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
-      )
-    target_link_libraries(${exename}${ARTIFACT_SUFFIX} ${LIBS} testutillib${ARTIFACT_SUFFIX})
-endforeach(sourcefile ${TEST_EXES})
-
-# C executables must link to a shared object
-set(C_TEST_EXES ${C_TESTS})
-
-foreach(sourcefile ${C_TEST_EXES})
-    string(REPLACE ".c" "" exename ${sourcefile})
-    string(REGEX REPLACE "^((.+)/)+" "" exename ${exename})
-    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile})
-    set_target_properties(${exename}${ARTIFACT_SUFFIX}
-      PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD_RELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_MINRELEASE 1
-      EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
-      )
-    target_link_libraries(${exename}${ARTIFACT_SUFFIX} vidardb${ARTIFACT_SUFFIX} testutillib${ARTIFACT_SUFFIX})
-endforeach(sourcefile ${C_TEST_EXES})
+# Installation and packaging for Linux
+if (NOT WIN32)
+install(TARGETS ${VIDARDB_STATIC_LIB} COMPONENT devel ARCHIVE DESTINATION lib64)
+install(TARGETS ${VIDARDB_SHARED_LIB} COMPONENT runtime DESTINATION lib64)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/vidardb/"
+        COMPONENT devel
+        DESTINATION include/vidardb)
+set(CMAKE_INSTALL_PREFIX /usr)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if (NOT WIN32)
 endif()
 
 set(BUILD_VERSION_CC ${CMAKE_BINARY_DIR}/build_version.cc)
-configure_file(util/build_version.cc.in ${BUILD_VERSION_CC} @ONLY)
+configure_file(util/build_version.cc ${BUILD_VERSION_CC} @ONLY)
 add_library(build_version OBJECT ${BUILD_VERSION_CC})
 target_include_directories(build_version PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/util)

--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -30,11 +30,10 @@
 # Our project depends on gflags, which requires users to take some extra steps
 # before they can compile the whole repository:
 #   1. Install gflags. You may download it from here:
-#      https://code.google.com/p/gflags/
-#   2. Once install, add the include path/lib path for gflags to CPATH and
-#      LIBRARY_PATH respectively. If installed with default mode, the
-#      lib and include path will be /usr/local/lib and /usr/local/include
-# Mac user can do this by having brew installed and running brew install gflags
+#      https://gflags.github.io/gflags/ (Mac users can `brew install gflags`)
+#   2. Once installed, add the include path for gflags to your CPATH env var and
+#      the lib path to LIBRARY_PATH. If installed with default settings, the lib
+#      will be /usr/local/lib and the include path will be /usr/local/include
 
 OUTPUT=$1
 if test -z "$OUTPUT"; then
@@ -288,7 +287,7 @@ EOF
     # Test whether numa is available
     $CXX $CFLAGS -x c++ - -o /dev/null -lnuma 2>/dev/null  <<EOF
       #include <numa.h>
-      #inlcude <numaif.h>
+      #include <numaif.h>
       int main() {}
 EOF
     if [ "$?" = 0 ]; then

--- a/build_tools/version.sh
+++ b/build_tools/version.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 if [ "$#" = "0" ]; then
-  echo "Usage: $0 major|minor|patch"
+  echo "Usage: $0 major|minor|patch|full"
   exit 1
 fi
+
 if [ "$1" = "major" ]; then
   cat include/vidardb/version.h  | grep MAJOR | head -n1 | awk '{print $3}'
 fi
@@ -11,4 +12,11 @@ if [ "$1" = "minor" ]; then
 fi
 if [ "$1" = "patch" ]; then
   cat include/vidardb/version.h  | grep PATCH | head -n1 | awk '{print $3}'
+fi
+if [ "$1" = "full" ]; then
+  awk '/#define VIDARDB/ { env[$2] = $3 }
+       END { printf "%s.%s.%s\n", env["VIDARDB_MAJOR"],
+                                  env["VIDARDB_MINOR"],
+                                  env["VIDARDB_PATCH"] }'  \
+      include/vidardb/version.h
 fi

--- a/src.mk
+++ b/src.mk
@@ -191,7 +191,6 @@ TEST_BENCH_SOURCES =                                                         \
   test/util/mock_env_test.cc                                                 \
   test/util/options_test.cc                                                  \
   test/util/event_logger_test.cc                                             \
-  test/util/rate_limiter_test.cc                                             \
   test/util/testharness.cc                                                   \
   test/util/testutil.cc                                                      \
   test/util/thread_list_test.cc                                              \

--- a/util/build_version.cc
+++ b/util/build_version.cc
@@ -1,5 +1,0 @@
-#include "build_version.h"
-const char* vidardb_build_git_sha =
-    "vidardb_build_git_sha:095bffa40bc381d2f63c44d3c78707bd04795910";
-const char* vidardb_build_git_date = "vidardb_build_git_date:2020-06-26";
-const char* vidardb_build_compile_date = __DATE__;

--- a/util/build_version.cc
+++ b/util/build_version.cc
@@ -1,0 +1,5 @@
+#include "build_version.h"
+const char* vidardb_build_git_sha =
+    "vidardb_build_git_sha:095bffa40bc381d2f63c44d3c78707bd04795910";
+const char* vidardb_build_git_date = "vidardb_build_git_date:2020-06-26";
+const char* vidardb_build_compile_date = __DATE__;


### PR DESCRIPTION
Now users can use `cmake` to build VidarDB. The size of shared library has also been reduced.